### PR TITLE
CARRY: fix buildah pipeline errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-ARG BASE_IMAGE
-ARG BUILDER_IMAGE
+ARG BUILDER_IMAGE=golang:1.23
+ARG BASE_IMAGE=gcr.io/distroless/static:nonroot
 
 # Build the manager binary
 FROM ${BUILDER_IMAGE} as builder


### PR DESCRIPTION
Buildah images should build on Konflux pipelines