### PR TITLE
CARRY: lower min kube version

### DIFF
--- a/bundle/manifests/lws.clusterserviceversion.yaml
+++ b/bundle/manifests/lws.clusterserviceversion.yaml
@@ -299,7 +299,7 @@ spec:
   - email: kehannon@redhat.com
     name: kevinhannon
   maturity: alpha
-  minKubeVersion: 1.32.0
+  minKubeVersion: 1.27.0
   provider:
     name: openshift
   version: 0.0.1


### PR DESCRIPTION
LWS can work with 1.27.0 at the moment so let's lower min kube version.