### PR TITLE
<CARRY>: Revert some redundant manual changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,37 +2,23 @@ ARG BUILDER_IMAGE=golang:1.23
 ARG BASE_IMAGE=gcr.io/distroless/static:nonroot
 
 # Build the manager binary
-FROM ${BUILDER_IMAGE} AS builder
-FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE} as builder
-
+FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE} AS builder
 ARG TARGETOS
 ARG TARGETARCH
 
 WORKDIR /workspace
-# Copy the Go Modules manifests
-COPY go.mod go.mod
-COPY go.sum go.sum
-
-# cache deps before building and copying source so that we don't need to re-download as much
+# cache deps before building so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
+COPY . .
 RUN go mod download
-
-# Copy the go source
-COPY cmd/main.go cmd/main.go
-COPY api/ api/
-COPY pkg/controllers/ pkg/controllers/
-COPY pkg/cert/ pkg/cert/
-COPY pkg/webhooks/ pkg/webhooks/
-COPY pkg/utils pkg/utils
-
 # Build
 # the GOARCH has not a default value to allow the binary be built according to the host where the command
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=${CGO_ENABLED:-1} GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
+RUN CGO_ENABLED=${CGO_ENABLED:-0} GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
 
-FROM ${BASE_IMAGE}
+FROM --platform=${BUILDPLATFORM} ${BASE_IMAGE}
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: gcr.io/k8s-staging-lws/lws
-  newTag: v0.4.0-65-g6367828-dirty
+  newTag: main


### PR DESCRIPTION
This PR reverts some manual changes in the fork that blocks the fork sync functionality due to conflicts. We don't need to make manual changes in Dockerfile (because we'll use ours `Dockerfile.ocp`) and we don't need to touch any configurations under `config` directory.