### PR TITLE
<CARRY>: CNTRLPLANE-211: Add Prow Dockerfile and Update Konflux Dockerfile accordingly

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,0 +1,4 @@
+build_root_image:
+  namespace: openshift
+  name: release
+  tag: rhel-9-release-golang-1.23-openshift-4.19

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,5 +1,5 @@
-ARG BUILDER_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23
-ARG BASE_IMAGE=registry.redhat.io/rhel9-4-els/rhel-minimal:9.4
+ARG BUILDER_IMAGE=registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19
+ARG BASE_IMAGE=registry.ci.openshift.org/ocp/builder:rhel-9-base-openshift-4.19
 
 # Build the manager binary
 FROM ${BUILDER_IMAGE} AS builder

--- a/OWNERS
+++ b/OWNERS
@@ -1,5 +1,11 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-
-approvers:
+reviewers:
+  - ardaguclu
+  - atiratree
   - kannon92
   - mrunalp
+approvers:
+  - ardaguclu
+  - atiratree
+  - kannon92
+  - mrunalp
+component: "kubernetes-sigs-lws"


### PR DESCRIPTION
This PR;

* Adds Prow dockerfile and ci-operator.yaml to initiate the foundational steps for testing
* Updates Konflux dockerfile to align with Prow one as well as required modifications for Konflux
* Updates OWNERS file by adding me and @atiratree

We have to diverge from upstream Dockerfile due to various constraints in our platform.