### PR TITLE
CNTRLPLANE-211: Add .snyk file to exclude unit tests and vendor directory

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,8 @@
+# References:
+# https://docs.snyk.io/scan-applications/snyk-code/using-snyk-code-from-the-cli/excluding-directories-and-files-from-the-snyk-code-cli-test
+# https://docs.snyk.io/snyk-cli/commands/ignore
+exclude:
+  global:
+    - vendor/**
+    - "**/*_test.go"
+    - pkg/utils/utils.go # Sha1Hash function is only used to generate a unique name, not be used due to security purposes


### PR DESCRIPTION
This PR https://github.com/openshift/release/pull/61443 ran snyk tool to scan the code base. This is the scan results https://storage.googleapis.com/test-platform-results/pr-logs/pull/openshift_release/61443/rehearse-61443-pull-ci-openshift-kubernetes-sigs-lws-main-security/1888904556499177472/build-log.txt.

I'll attempt to fix some of the failures in upstream. However, we have limited power on vendor directory. So that we can't be easily obliged to fix the scan results that are found for `vendor` directory (even if you fix something, that might not be backported, the results might be false positive, etc.)

This PR excludes `vendor` and unit test directories for snyk scans. We will be notified in Jira, when there is something we have to fix. 