### PR TITLE
CNTRLPLANE-211: Use rhel9 base image without ocp version tag

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,5 +1,5 @@
 ARG BUILDER_IMAGE=registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19
-ARG BASE_IMAGE=registry.ci.openshift.org/ocp/builder:rhel-9-base-openshift-4.19
+ARG BASE_IMAGE=registry.ci.openshift.org/ocp/builder:base-rhel9
 
 # Build the manager binary
 FROM ${BUILDER_IMAGE} AS builder


### PR DESCRIPTION
As explained in https://github.com/openshift/release/pull/61493#issue-2844417431, there is no need to have a OCP version tag in rhel9 base image, as it can mislead people.