### PR TITLE
CNTRLPLANE-309: <CARRY>: Add ocp specific makefile to customize targets

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -3,21 +3,21 @@ ARG BASE_IMAGE=registry.ci.openshift.org/ocp/4.19:base-rhel9
 
 # Build the manager binary
 FROM ${BUILDER_IMAGE} AS builder
-
 ARG TARGETOS
 ARG TARGETARCH
 ARG TARGETPLATFORM
 
-ENV GOEXPERIMENT=strictfipsruntime
-
 WORKDIR /workspace
 COPY . .
 
-RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -tags strictfipsruntime -mod=vendor -a -o manager cmd/main.go
+ENV GOEXPERIMENT=strictfipsruntime
+ENV GOFLAGS="-tags=strictfipsruntime -mod=vendor -a"
+
+RUN make -f Makefile-ocp.mk build-ocp GO_BUILD_ENV='CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH}'
 
 FROM --platform=$TARGETPLATFORM ${BASE_IMAGE}
 WORKDIR /
-COPY --from=builder /workspace/manager .
+COPY --from=builder /workspace/bin/manager .
 RUN mkdir /licenses
 COPY --from=builder /workspace/LICENSE /licenses/.
 USER 65532:65532

--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -3,21 +3,21 @@ ARG BASE_IMAGE=registry.redhat.io/rhel9-4-els/rhel-minimal:9.4
 
 # Build the manager binary
 FROM ${BUILDER_IMAGE} AS builder
-
 ARG TARGETOS
 ARG TARGETARCH
 ARG TARGETPLATFORM
 
-ENV GOEXPERIMENT=strictfipsruntime
-
 WORKDIR /workspace
 COPY . .
 
-RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -tags strictfipsruntime -mod=vendor -a -o manager cmd/main.go
+ENV GOEXPERIMENT=strictfipsruntime
+ENV GOFLAGS="-tags=strictfipsruntime -mod=vendor -a"
+
+RUN make -f Makefile-ocp.mk build-ocp GO_BUILD_ENV='CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH}'
 
 FROM --platform=$TARGETPLATFORM ${BASE_IMAGE}
 WORKDIR /
-COPY --from=builder /workspace/manager .
+COPY --from=builder /workspace/bin/manager .
 RUN mkdir /licenses
 COPY --from=builder /workspace/LICENSE /licenses/.
 USER 65532:65532

--- a/Makefile-ocp.mk
+++ b/Makefile-ocp.mk
@@ -1,0 +1,12 @@
+include Makefile
+
+.PHONY: verify-ocp
+verify-ocp: manifests
+	@if !(git diff --quiet HEAD); then \
+		git diff; \
+		echo "manifests are out of date, run make manifests"; exit 1; \
+	fi
+
+.PHONY: build-ocp
+build-ocp: fmt vet
+	$(GO_BUILD_ENV) $(GO_CMD) build -ldflags="$(LD_FLAGS)" -o bin/manager cmd/main.go


### PR DESCRIPTION
In upstream, `make build` first [generates manifests](https://github.com/kubernetes-sigs/lws/blob/639147f37af179c10cda38046dd8a6a1fadd080e/Makefile#L154), runs fmt and vet and after that it proceeds the actual build. However, generating manifests requires the installation of controller-gen binary. 

In order to support hermetic builds, we shouldn't access to internet to install anything. So that our options are;
* Carrying controller-gen binary in our repository: As we agreed upon, this is unwanted.
* Importing controller-gen as a go module under tools directory and build it: This doesn't work. Because when we build the controller-gen binary manually, it's version is always set `unknown` (although required tags are correctly set) and it generates unexpected outputs, such as this https://github.com/kubernetes-sigs/lws/blob/639147f37af179c10cda38046dd8a6a1fadd080e/config/crd/bases/leaderworkerset.x-k8s.io_leaderworkersets.yaml#L6 is modified to `unknown` which is unacceptable.

I've followed a different, simpler option. We don't need to generate manifests in every build operation. This PR removes `manifests` target from the `build` target by assuming that manifests are correctly generated already (manifests must always be correctly generated before the build step). This PR populates a new target in `verify` to generate manifests and expects no diff. This target will be run in `verify` job.