### PR TITLE
CNTRLPLANE-118: Re-enable coverity checks

### DIFF
--- a/.tekton/lws-main-pull-request.yaml
+++ b/.tekton/lws-main-pull-request.yaml
@@ -87,10 +87,6 @@ spec:
         name: skip-checks
         type: string
       - default: "true"
-        description: Skip checks against built image
-        name: skip-coverity-checks
-        type: string
-      - default: "true"
         description: Execute the build with network isolation
         name: hermetic
         type: string
@@ -481,7 +477,7 @@ spec:
               value: task
           resolver: bundles
         when:
-          - input: $(params.skip-coverity-checks)
+          - input: $(params.skip-checks)
             operator: in
             values:
               - "false"
@@ -502,7 +498,7 @@ spec:
               value: task
           resolver: bundles
         when:
-          - input: $(params.skip-coverity-checks)
+          - input: $(params.skip-checks)
             operator: in
             values:
               - "false"

--- a/.tekton/lws-main-push.yaml
+++ b/.tekton/lws-main-push.yaml
@@ -116,6 +116,9 @@ spec:
           VMs
         name: privileged-nested
         type: string
+      - default: snyk-secret
+        description: Snyk Token Secret Name
+        name: snyk-secret
       - default:
           - linux/x86_64
           - linux/arm64

--- a/.tekton/lws-main-push.yaml
+++ b/.tekton/lws-main-push.yaml
@@ -84,10 +84,6 @@ spec:
         name: skip-checks
         type: string
       - default: "true"
-        description: Skip checks against built image
-        name: skip-coverity-checks
-        type: string
-      - default: "true"
         description: Execute the build with network isolation
         name: hermetic
         type: string
@@ -475,7 +471,7 @@ spec:
               value: task
           resolver: bundles
         when:
-          - input: $(params.skip-coverity-checks)
+          - input: $(params.skip-checks)
             operator: in
             values:
               - "false"
@@ -496,7 +492,7 @@ spec:
               value: task
           resolver: bundles
         when:
-          - input: $(params.skip-coverity-checks)
+          - input: $(params.skip-checks)
             operator: in
             values:
               - "false"


### PR DESCRIPTION
Coverity checks were temporarily disabled due to the misconfigured secrets. Now we should have successfully imported secrets and these tasks should work.

This PR re-enables coverity checks to return default behavior.