### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for lws-1-0

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -23,7 +23,8 @@ COPY --from=builder /workspace/LICENSE /licenses/.
 USER 65532:65532
 
 LABEL com.redhat.component="Leader Worker Set"
-LABEL name="lws"
+LABEL cpe="cpe:/a:redhat:leader_worker_set:1.0::el9"
+LABEL name="leader-worker-set/lws-rhel9"
 LABEL release="0.7.0"
 LABEL version="0.7.0"
 LABEL maintainer="support@redhat.com"


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
