### PR TITLE
NO-JIRA: switch to ubi micro

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,5 +1,5 @@
 ARG BUILDER_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26
-ARG BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:34880b64c07f28f64d95737f82f891516de9a3b43583f39970f7bf8e4cfa48b7
+ARG BASE_IMAGE=registry.redhat.io/ubi9/ubi-micro@sha256:b1e86b97028b8fcfb6d85f997c39e6b6b67496163ef8d80d243220a4918e8bef
 
 # Build the manager binary
 FROM ${BUILDER_IMAGE} AS builder


### PR DESCRIPTION
Switch to ubi micro to minimize CVE attack surface.